### PR TITLE
Path to CSS file

### DIFF
--- a/_layouts/template_fileindex.html
+++ b/_layouts/template_fileindex.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-<link rel="stylesheet" type="text/css" href="{{ "./assets/css/style.css" }}">
+<link rel="stylesheet" type="text/css" href="./assets/css/style.css">
 </head>
 <body>
 <header>

--- a/_layouts/template_fileindex.html
+++ b/_layouts/template_fileindex.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-<link rel="stylesheet" type="text/css" href="{{ "./../assets/css/style.css" }}">
+<link rel="stylesheet" type="text/css" href="{{ "./assets/css/style.css" }}">
 </head>
 <body>
 <header>


### PR DESCRIPTION
I made the following changes:

- Changed `./../` to `./` to correct the relative path
- Removed `{{` and `}}` from the path because no variable is being used here

To inspect the changes, please click the **Files changed** tab of this pull request. If you're fine with the changes, please merge them with the main branch.